### PR TITLE
Fix spurious discriminated-union ValidationError after plugin reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.5.1 - ?
 
+- Fix spurious discriminated-union `ValidationError` on slice models with forward-referenced fields after a compile reloaded the plugin modules.
 
 ## v0.5.0 - 2026-06-06
 

--- a/inmanta_plugins/git_ops/slice.py
+++ b/inmanta_plugins/git_ops/slice.py
@@ -198,6 +198,33 @@ def resolve_forward_reference(
     return getattr(module, name, None), name
 
 
+def raw_forward_reference_name(owner_cls: type, attribute: str) -> str | None:
+    """
+    Recover the name of the forward reference used in the (raw) annotation of
+    the given attribute, peeling one level of container (e.g. ``Sequence`` or
+    an ``Optional``) to reach the element.  Return None if the annotation does
+    not contain any forward reference.
+
+    Pydantic mutates ``model_fields[...].annotation`` to the resolved type when
+    a model is rebuilt, which erases the forward-reference name.  The class
+    ``__annotations__`` are never mutated, so they remain a reliable source for
+    that name regardless of the model's rebuild state.
+
+    :param owner_cls: The class on which the attribute is defined.
+    :param attribute: The name of the attribute whose annotation to inspect.
+    """
+    raw = owner_cls.__annotations__.get(attribute)
+    if raw is None:
+        return None
+
+    for candidate in (raw, *typing.get_args(raw)):
+        _, name = resolve_forward_reference(candidate, owner_cls)
+        if name is not None:
+            return name
+
+    return None
+
+
 def discriminated_union(
     annotation: object, owner_cls: type, *, fallback_name: str | None
 ) -> tuple[str, str, Sequence[type]] | None:
@@ -213,6 +240,12 @@ def discriminated_union(
         derived from a forward reference (e.g. the relation attribute name).
     """
     resolved, name = resolve_forward_reference(annotation, owner_cls)
+    if name is None and fallback_name is not None:
+        # The annotation reaching us has already been resolved (e.g. the model
+        # was rebuilt to bind it to its own classes), so it no longer carries
+        # the forward-reference name we use to name the union entity.  Recover
+        # that name from the raw class annotation, which is never mutated.
+        name = raw_forward_reference_name(owner_cls, fallback_name)
     if name is None:
         name = fallback_name
 
@@ -546,6 +579,46 @@ class SliceEntitySchema:
         return count > 1
 
 
+# Registry of all the slice model classes that have been defined.  It is used
+# to eagerly resolve their (possibly forward-referenced) annotations before an
+# inmanta compile can swap the plugin modules in sys.modules.  See
+# rebuild_slice_models for the details.
+_SLICE_MODELS: list[type["EmbeddedSliceObjectABC"]] = []
+
+
+def rebuild_slice_models() -> None:
+    """
+    Eagerly resolve the (possibly forward-referenced) annotations of all the
+    registered slice models, binding each model to the classes currently in
+    scope.
+
+    Pydantic resolves forward references lazily, on the first validation, by
+    looking the referenced name up in ``sys.modules[cls.__module__]``.  The
+    inmanta compiler reloads plugin modules by replacing their ``sys.modules``
+    entry with a fresh module object holding brand new class objects.  A model
+    whose forward references are still unresolved when its first validation
+    happens *after* such a reload resolves them against the new module, while a
+    long-lived consumer (e.g. a test imported at collection time) still holds
+    instances built from the old module.  The discriminated union then rejects
+    an instance of the very class it expects, raising a spurious
+    ``ValidationError``.
+
+    Forcing the resolution eagerly, when a store is registered (by which point
+    the whole plugin module, including the unions defined after the models, is
+    defined), binds every model to its own classes before any reload can swap
+    them out.
+    """
+    for model in _SLICE_MODELS:
+        if model.__pydantic_complete__:
+            # Already resolved, binding it again would be a no-op.
+            continue
+
+        # raise_errors=False: a model may still reference a name that is not
+        # defined yet (e.g. its union lives in a module not imported yet).  It
+        # will be rebuilt by a later store registration.
+        model.model_rebuild(force=True, raise_errors=False)
+
+
 def docstring(c: type) -> str | None:
     """
     Extract the docstring of a class definition (if there is any). Format
@@ -565,6 +638,12 @@ class EmbeddedSliceObjectABC(pydantic.BaseModel):
     """
 
     keys: typing.ClassVar[Sequence[str]] = tuple()
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        # Keep track of every slice model so its forward references can be
+        # resolved eagerly when a store is registered.  See rebuild_slice_models.
+        _SLICE_MODELS.append(cls)
 
     operation: SkipJsonSchema[str] = pydantic.Field(
         default="create",

--- a/inmanta_plugins/git_ops/store.py
+++ b/inmanta_plugins/git_ops/store.py
@@ -288,6 +288,12 @@ class SliceStore[S: slice.SliceObjectABC]:
 
         self.register_store()
 
+        # Eagerly resolve the forward references of all the slice models now
+        # that this store's module is fully defined.  This binds the models to
+        # their own classes before an inmanta compile can reload the plugin
+        # modules out from under a long-lived consumer.
+        slice.rebuild_slice_models()
+
     @property
     def source_path(self) -> pathlib.Path:
         """

--- a/tests/test_slice_reload.py
+++ b/tests/test_slice_reload.py
@@ -1,0 +1,88 @@
+"""
+Copyright 2026 Guillaume Everarts de Velp
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: edvgui@gmail.com
+"""
+
+import importlib
+import sys
+import types
+from collections.abc import Generator
+
+import pytest
+
+from inmanta.loader import unload_inmanta_plugins
+
+
+@pytest.fixture(autouse=True)
+def restore_sys_modules() -> Generator[None, None, None]:
+    """
+    These tests reload the plugin modules, which mutates ``sys.modules``
+    globally.  Snapshot it and restore the original module objects afterwards so
+    that other test modules (which captured their imports at collection time)
+    keep seeing the same objects.
+    """
+    snapshot = dict(sys.modules)
+    try:
+        yield
+    finally:
+        sys.modules.clear()
+        sys.modules.update(snapshot)
+        importlib.invalidate_caches()
+
+
+def fresh_import(module: str) -> types.ModuleType:
+    """
+    Unload all inmanta plugin modules and import the given one again, mimicking
+    what the inmanta compiler does at the start of a compile: replace the
+    sys.modules entries with brand new module objects holding brand new class
+    objects.
+    """
+    unload_inmanta_plugins()
+    return importlib.import_module(module)
+
+
+def test_discriminated_union_survives_plugin_reload() -> None:
+    """
+    A slice model carrying a forward-referenced discriminated-union field (the
+    union is defined after the model, like ``Folder.content``) used to raise a
+    spurious ``ValidationError`` the first time it was validated after a compile
+    reloaded the plugin modules.
+
+    Pydantic resolves the forward reference lazily, against
+    ``sys.modules[model.__module__]``.  After a reload that entry holds a brand
+    new ``File`` class, while a long-lived consumer still holds an instance of
+    the old ``File``.  The discriminated union then rejects an instance of the
+    very class it expects.  Registering a store now resolves all the slice
+    models eagerly, binding each to its own classes before any reload.
+    """
+    # Start from a clean import so the outcome does not depend on whichever
+    # model an earlier test happened to validate (the bug is masked once a
+    # model's schema has been built before the reload).
+    fs = fresh_import("inmanta_plugins.example.slices.fs")
+
+    # A leaf instance built from the freshly imported classes.  ``File`` has no
+    # union field, so building it does not resolve ``Folder``'s union: that
+    # resolution is what must survive the reload.
+    leaf = fs.File(name="a.txt", content="a")
+    folder_cls = fs.Folder
+
+    # The compiler reloads the plugins: a brand new module replaces the old one.
+    fresh_import("inmanta_plugins.example.slices.fs")
+
+    # Validating the old ``Folder`` for the first time, after the reload, must
+    # accept the old ``File`` instance instead of rejecting it.
+    folder = folder_cls(name="b", content=[leaf])
+    assert folder.content == [leaf]

--- a/tests/test_slice_schema.py
+++ b/tests/test_slice_schema.py
@@ -20,7 +20,7 @@ import typing
 from collections.abc import Sequence
 
 import pydantic
-from inmanta_plugins.example.slices.fs import File, RootFolder
+from inmanta_plugins.example.slices.fs import File, Folder, RootFolder
 from inmanta_plugins.example.slices.recursive import EmbeddedSlice, Slice
 from inmanta_plugins.example.slices.simple import Slice as SimpleSlice
 
@@ -177,6 +177,32 @@ def test_scaffold_embedded_defaults() -> None:
         # A default that can not be constructed falls back to the placeholder
         "invalid": const.SLICE_PLACEHOLDER,
     }
+
+
+def test_discriminated_union_entity_name() -> None:
+    """
+    The discriminated union entity is named after the forward reference used in
+    the field annotation (``Sequence["FolderContent"]``), and that name must be
+    recovered even when the model has been rebuilt and its field annotation
+    resolved to the concrete union type.  Slice models are rebuilt eagerly when
+    their store is registered, so ``Folder.content`` is already in its resolved
+    form here.
+    """
+    # Precondition: the model has been rebuilt, so the field annotation no
+    # longer carries the "FolderContent" forward reference.
+    assert Folder.__pydantic_complete__
+    assert typing.get_args(Folder.model_fields["content"].annotation) != (
+        "FolderContent",
+    )
+
+    schema = RootFolder.entity_schema()
+    content = next(r for r in schema.all_relations() if r.name == "content")
+
+    # The union entity keeps its forward-reference name instead of falling back
+    # to the (invalid, lower-case) relation attribute name.
+    assert content.entity.name == "FolderContent"
+    assert content.entity.discriminator == "type"
+    assert {sub.name for sub in content.entity.sub_entities} == {"Folder", "File"}
 
 
 def test_scaffold_discriminated_union() -> None:


### PR DESCRIPTION
Slice models with a forward-referenced field (e.g. a discriminated union defined after the model, like Folder.content) raised a spurious pydantic ValidationError the first time they were validated after an inmanta compile reloaded the plugin modules. Pydantic resolves forward references lazily against sys.modules[cls.__module__], which the compiler swaps for a fresh module; a long-lived consumer still holding old-module instances then has its union reject an instance of the very class it expects.

Resolve forward references eagerly when a store is registered, binding each model to its own classes before any reload can swap them out. Because the rebuild rewrites model_fields[...].annotation to the resolved type (erasing the forward-reference name the generator uses to name the union entity), recover that name from the never-mutated cls.__annotations__, making the generator robust to both the forward-reference and the resolved-class form.