### PR TITLE
Issue/update scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v0.5.2 - ?
+## v0.6.0 - ?
+
+- Only insert the `update` operation on slice elements whose content actually changed, instead of on every element of a slice that has more than one version.  Unchanged elements keep the `create` operation; `create` and `delete` are unaffected.
 
 
 ## v0.5.1 - 2026-06-13

--- a/inmanta_plugins/git_ops/store.py
+++ b/inmanta_plugins/git_ops/store.py
@@ -89,12 +89,13 @@ class SliceFile[S: slice.SliceObjectABC]:
             # The slice has been deleted
             return {}
 
-        # Load default values (and model only values)
-        return (
-            pydantic.TypeAdapter(self.schema)
-            .validate_python(attributes)
-            .model_dump(mode="json")
-        )
+        with slice.exclude_model_values():
+            # Load default values
+            return (
+                pydantic.TypeAdapter(self.schema)
+                .validate_python(attributes)
+                .model_dump(mode="json")
+            )
 
     def write_raw(self, attributes: dict) -> None:
         """
@@ -604,9 +605,14 @@ class SliceStore[S: slice.SliceObjectABC]:
                     merge_attributes(
                         p_current,
                         p_previous,
-                        operation=const.SLICE_DELETE,
                         path=dict_path.NullPath(),
                         schema=self.schema.entity_schema(),
+                        # Don't insert the path yet and keep create operation implicit
+                        # to avoid trigerring a diff when there is not one
+                        # Other operations can be shown as we want to make sure that the
+                        # last merge knows some past change might not be settled yet
+                        insert_path=False,
+                        implicit_create_operation=True,
                     ),
                     *previous[2:],
                 ]
@@ -658,9 +664,8 @@ class SliceStore[S: slice.SliceObjectABC]:
                 # We need to get the attributes of the last undeleted
                 # version, otherwise we don't know what we have to delete
                 attributes = merge_attributes(
-                    current=previous_slices[s].attributes,
+                    current=None,
                     previous=previous_slices[s].attributes,
-                    operation=const.SLICE_DELETE,
                     path=dict_path.NullPath(),
                     schema=self.schema.entity_schema(),
                 )
@@ -670,7 +675,6 @@ class SliceStore[S: slice.SliceObjectABC]:
                 attributes = merge_attributes(
                     current=current.attributes,
                     previous=None if new else previous_slices[s].attributes,
-                    operation="create" if new else "update",
                     path=dict_path.NullPath(),
                     schema=self.schema.entity_schema(),
                 )
@@ -1003,15 +1007,12 @@ class SliceStore[S: slice.SliceObjectABC]:
         try:
             # If the embedded slice is the root slice, we just get the empty
             # slice
-            parent_value = get_parent_path(path).get_element(source)
+            get_parent_path(path).get_element(source)
         except LookupError:
             # If the embedded slice has been removed, we get a lookup
             # error
-            parent_value = {}
-
-        if parent_value.get("operation", const.SLICE_DELETE) == const.SLICE_DELETE:
             raise RuntimeError(
-                f"Can not set attribute on deleted slice: {repr(str(parent_value))} in "
+                f"Can not set attribute on deleted slice: {str(path)} in "
                 f"Slice(name={repr(name)}) is deleted from source slice and can not "
                 "be modified."
             )
@@ -1172,14 +1173,76 @@ def clear_project_paths() -> None:
         store._active_path = None
 
 
+def resolve_operation(
+    current: object,
+    previous: object,
+) -> typing.Literal["create", "update", "delete"]:
+    """
+    Resolve the operation flagging how the current differentiate from the previous.
+    Possible outcome:
+        - create: the current and previous are the same, or there was no previous
+        - update: the current and previous are different
+        - delete: there is no current but there was a previous
+    """
+    match current, previous:
+        case _, None:
+            return const.SLICE_CREATE
+        case None, _:
+            return const.SLICE_DELETE
+        case _ if current == previous:
+            return const.SLICE_CREATE
+        case _:
+            return const.SLICE_UPDATE
+
+
+@typing.overload
+def merge_attributes(
+    current: None,
+    previous: None,
+    *,
+    path: dict_path.DictPath,
+    schema: slice.SliceEntitySchema,
+    implicit_create_operation: bool = False,
+    insert_path: bool = True,
+) -> None:
+    pass
+
+
+@typing.overload
+def merge_attributes(
+    current: dict | None,
+    previous: dict,
+    *,
+    path: dict_path.DictPath,
+    schema: slice.SliceEntitySchema,
+    implicit_create_operation: bool = False,
+    insert_path: bool = True,
+) -> dict:
+    pass
+
+
+@typing.overload
 def merge_attributes(
     current: dict,
     previous: dict | None,
     *,
-    operation: typing.Literal["create", "update", "delete"],
     path: dict_path.DictPath,
     schema: slice.SliceEntitySchema,
+    implicit_create_operation: bool = False,
+    insert_path: bool = True,
 ) -> dict:
+    pass
+
+
+def merge_attributes(
+    current: dict | None,
+    previous: dict | None,
+    *,
+    path: dict_path.DictPath,
+    schema: slice.SliceEntitySchema,
+    implicit_create_operation: bool = False,
+    insert_path: bool = True,
+) -> dict | None:
     """
     Construct a merge of the current and previous attributes, inserting
     all the attributes that were removed, marking them as purged. The
@@ -1188,10 +1251,16 @@ def merge_attributes(
     by the key that leads to it.  Any other type will be considered to be
     a primitive and the value of the current will be kept unmodified.
     """
-    merged = {
-        "operation": operation,
-        "path": str(path),
-    }
+    if current is None and previous is None:
+        return None
+
+    merged: dict[str, object] = {}
+    if insert_path:
+        merged["path"] = str(path)
+
+    operation = resolve_operation(current, previous)
+    if operation != const.SLICE_CREATE or not implicit_create_operation:
+        merged["operation"] = operation
 
     # When the schema is the base of a discriminated union, resolve the
     # concrete sub entity matching this instance so that we merge all of its
@@ -1203,140 +1272,90 @@ def merge_attributes(
     for attribute in schema.all_attributes():
         if attribute.name in ["operation", "path"]:
             continue
-        merged[attribute.name] = current.get(attribute.name)
+        match current, previous:
+            case None, dict():
+                merged[attribute.name] = previous.get(attribute.name)
+            case dict(), _:
+                merged[attribute.name] = current.get(attribute.name)
+            case _:
+                raise ValueError(
+                    f"Current and previous can not both be None!  But it is the case for path {path}"
+                )
 
     # Go over all relations
     for relation in schema.all_relations():
-        cardinality = (relation.cardinality_min, relation.cardinality_max)
-        if cardinality == (1, 1):
-            # The relation is mandatory, we will always have the
-            # current attributes
-            merged[relation.name] = merge_attributes(
-                current=typing.cast(dict, current[relation.name]),
-                previous=(
-                    typing.cast(dict, previous[relation.name])
-                    if previous is not None
-                    else None
-                ),
-                operation=operation,
-                path=path + dict_path.InDict(relation.name),
-                schema=relation.entity,
-            )
-            continue
-
-        if cardinality == (0, 1):
-            # Optional relation, see if the current value is still set, if it
-            # is not, take the previous one and mark is as "delete"
-            current_value = typing.cast(dict | None, current.get(relation.name))
-            previous_value = (
-                typing.cast(dict | None, previous.get(relation.name))
-                if previous is not None
-                else None
-            )
-            item_path = path + dict_path.InDict(relation.name)
-            match (current_value, previous_value):
-                case None, None:
+        if relation.cardinality_max == 1:
+            # Direct relation
+            match current, previous:
+                case None, dict():
+                    merged[relation.name] = merge_attributes(
+                        current=None,
+                        previous=previous.get(relation.name),
+                        path=path + dict_path.InDict(relation.name),
+                        schema=relation.entity,
+                        insert_path=insert_path,
+                        implicit_create_operation=implicit_create_operation,
+                    )
+                case dict(), None:
+                    merged[relation.name] = merge_attributes(
+                        current=current.get(relation.name),
+                        previous=None,
+                        path=path + dict_path.InDict(relation.name),
+                        schema=relation.entity,
+                        insert_path=insert_path,
+                        implicit_create_operation=implicit_create_operation,
+                    )
+                case dict(), dict():
+                    merged[relation.name] = merge_attributes(
+                        current=current.get(relation.name),
+                        previous=previous.get(relation.name),
+                        path=path + dict_path.InDict(relation.name),
+                        schema=relation.entity,
+                        insert_path=insert_path,
+                        implicit_create_operation=implicit_create_operation,
+                    )
+                case _:
                     merged[relation.name] = None
-                case None, dict():
-                    # This is a deletion, recurse it
-                    merged[relation.name] = merge_attributes(
-                        previous_value,
-                        previous_value,
-                        operation=const.SLICE_DELETE,
-                        path=item_path,
-                        schema=relation.entity,
-                    )
-                case dict(), _:
-                    merged[relation.name] = merge_attributes(
-                        current_value,
-                        previous_value,
-                        operation=(
-                            operation
-                            if operation == const.SLICE_DELETE
-                            else (
-                                const.SLICE_CREATE
-                                if previous_value is None
-                                else const.SLICE_UPDATE
-                            )
-                        ),
-                        path=item_path,
-                        schema=relation.entity,
-                    )
-                case _:
-                    raise ValueError()
-            continue
+        else:
+            # Relation, attribute should be a list, and should be merged.  For a
+            # discriminated union, resolve each item to its concrete sub entity so
+            # that the identity includes the discriminator.
+            def identity(value: dict) -> Sequence[tuple[str, object]]:
+                return relation.entity.resolve(value).instance_identity(value)
 
-        # Relation, attribute should be a list, and should be merged.  For a
-        # discriminated union, resolve each item to its concrete sub entity so
-        # that the identity includes the discriminator.
-        def identity(value: dict) -> Sequence[tuple[str, object]]:
-            return relation.entity.resolve(value).instance_identity(value)
+            current_values = {
+                identity(current_value): current_value
+                for current_value in typing.cast(
+                    list[dict], current[relation.name] if current is not None else []
+                )
+            }
+            previous_values = {
+                identity(previous_value): previous_value
+                for previous_value in typing.cast(
+                    list[dict], previous[relation.name] if previous is not None else []
+                )
+            }
 
-        current_values = {
-            identity(current_value): current_value
-            for current_value in typing.cast(list[dict], current[relation.name])
-        }
-        previous_values = {
-            identity(previous_value): previous_value
-            for previous_value in typing.cast(
-                list[dict], previous[relation.name] if previous is not None else []
-            )
-        }
+            # Gather the identities of all the previous and current embedded entities
+            # without losing the order
+            all_identities = list(current_values.keys())
+            for prev_id in previous_values:
+                if prev_id not in current_values:
+                    all_identities.append(prev_id)
 
-        # Gather the identities of all the previous and current embedded entities
-        # without losing the order
-        all_identities = [
-            identity(current_value)
-            for current_value in typing.cast(list[dict], current[relation.name])
-        ]
-        if previous is not None:
-            all_identities.extend(
-                [
-                    key
-                    for previous_value in typing.cast(
-                        list[dict], previous[relation.name]
-                    )
-                    if (key := identity(previous_value)) not in current_values
-                ]
-            )
-
-        merged_relation: list[dict] = []
-        merged[relation.name] = merged_relation
-        for key in all_identities:
-            current_value = current_values.get(key)
-            previous_value = previous_values.get(key)
-            item_path = path + dict_path.KeyedList(relation.name, key)
-            match (current_value, previous_value):
-                case None, dict():
-                    # This is a deletion, recurse it
-                    merged_relation.append(
-                        merge_attributes(
-                            previous_value,
-                            previous_value,
-                            operation=const.SLICE_DELETE,
-                            path=item_path,
-                            schema=relation.entity,
-                        )
-                    )
-                case dict(), _:
-                    merged_relation.append(
-                        merge_attributes(
-                            current_value,
-                            previous_value,
-                            operation=(
-                                operation
-                                if operation == const.SLICE_DELETE
-                                else (
-                                    const.SLICE_CREATE
-                                    if previous_value is None
-                                    else const.SLICE_UPDATE
-                                )
-                            ),
-                            path=item_path,
-                            schema=relation.entity,
-                        )
-                    )
-                case _:
-                    raise ValueError()
+            merged_relation: list[dict] = []
+            merged[relation.name] = merged_relation
+            for key in all_identities:
+                item_path = path + dict_path.KeyedList(relation.name, key)
+                merged_item = merge_attributes(
+                    current_values.get(key),
+                    previous_values.get(key),
+                    path=item_path,
+                    schema=relation.entity,
+                    insert_path=insert_path,
+                    implicit_create_operation=implicit_create_operation,
+                )
+                if merged_item is not None:
+                    merged_relation.append(merged_item)
 
     return merged

--- a/inmanta_plugins/git_ops/store.py
+++ b/inmanta_plugins/git_ops/store.py
@@ -572,44 +572,6 @@ class SliceStore[S: slice.SliceObjectABC]:
 
         return self.current_slices
 
-    def _preceding_versions(self, name: str, current: Slice) -> list[dict]:
-        """
-        Return the attributes of all the active versions of the slice that
-        precede the current one, sorted from the most to the least recent.
-
-        :param name: The name of the slice.
-        :param current: The slice currently in use for this name.
-        """
-        previous = [
-            s.attributes
-            for s in sorted(
-                self.load_active_slices().get(name, []),
-                key=lambda s: s.version,
-                reverse=True,
-            )
-        ]
-        if current == self.get_latest_slice(name):
-            # The current slice is the latest active one, drop it so we only
-            # keep the versions strictly preceding it.
-            previous = previous[1:]
-        return previous
-
-    def previous_version_attributes(self, name: str) -> dict | None:
-        """
-        Get the attributes of the version immediately preceding the current
-        one, or None if the slice has no previous version.
-
-        Unlike load_previous_slices, the returned attributes are not collapsed
-        together with even older versions: they are the raw content of the
-        immediately preceding version.  This is the reference to use when
-        deciding whether a slice element changed, as deletions carried over
-        from older versions are not part of the immediately preceding content.
-
-        :param name: The name of the slice.
-        """
-        previous = self._preceding_versions(name, self.load_current_slices()[name])
-        return previous[0] if previous else None
-
     def load_previous_slices(self) -> dict[str, Slice]:
         """
         Load all the previous slices (for slices which have an older version
@@ -618,9 +580,22 @@ class SliceStore[S: slice.SliceObjectABC]:
         if self.previous_slices is not None:
             return self.previous_slices
 
+        active_slices = self.load_active_slices()
+
         self.previous_slices: dict[str, Slice] = {}
         for s, current in self.load_current_slices().items():
-            previous = self._preceding_versions(s, current)
+            latest = self.get_latest_slice(s)
+
+            previous = [
+                s.attributes
+                for s in sorted(
+                    active_slices.get(s, []),
+                    key=lambda s: s.version,
+                    reverse=True,
+                )
+            ]
+            if current == latest:
+                previous = previous[1:]
 
             while len(previous) >= 2:
                 p_current = previous[0]
@@ -690,36 +665,14 @@ class SliceStore[S: slice.SliceObjectABC]:
                     schema=self.schema.entity_schema(),
                 )
             else:
-                # Normal merge.  The slice is a creation when it has no
-                # previous version, an update when its content changed compared
-                # to the version immediately preceding it, and is otherwise
-                # left as a creation: it is part of the desired state but
-                # carries no change.
+                # Normal merge
                 new = s not in previous_slices
-                if new:
-                    operation: typing.Literal["create", "update", "delete"] = (
-                        const.SLICE_CREATE
-                    )
-                    baseline = None
-                else:
-                    baseline = self.previous_version_attributes(s)
-                    assert baseline is not None
-                    operation = (
-                        const.SLICE_UPDATE
-                        if content_changed(
-                            current.attributes,
-                            baseline,
-                            schema=self.schema.entity_schema(),
-                        )
-                        else const.SLICE_CREATE
-                    )
                 attributes = merge_attributes(
                     current=current.attributes,
                     previous=None if new else previous_slices[s].attributes,
-                    operation=operation,
+                    operation="create" if new else "update",
                     path=dict_path.NullPath(),
                     schema=self.schema.entity_schema(),
-                    baseline=baseline,
                 )
 
             # Merge the current and previous slices together
@@ -1219,131 +1172,6 @@ def clear_project_paths() -> None:
         store._active_path = None
 
 
-def content_changed(
-    current: dict,
-    previous: dict,
-    *,
-    schema: slice.SliceEntitySchema,
-) -> bool:
-    """
-    Determine whether the content of a slice element changed between the
-    version immediately preceding the current one and the current version.
-
-    The comparison is recursive: an element changed if any of its own
-    (primitive) attributes differ, or if any of its embedded elements was
-    added, removed or itself changed.  The inserted "operation" and "path"
-    metadata are ignored, as they are not part of the user-defined content.
-
-    :param current: The attributes of the element in the current version.
-    :param previous: The attributes of the element in the version immediately
-        preceding the current one.
-    :param schema: The schema of the element being compared.
-    """
-    # When the schema is the base of a discriminated union, resolve the
-    # concrete sub entity matching the current instance.
-    schema = schema.resolve(current)
-
-    # Compare the primitive attributes, ignoring the inserted metadata.
-    for attribute in schema.all_attributes():
-        if attribute.name in ["operation", "path"]:
-            continue
-        if current.get(attribute.name) != previous.get(attribute.name):
-            return True
-
-    # Compare the embedded entities.
-    for relation in schema.all_relations():
-        cardinality = (relation.cardinality_min, relation.cardinality_max)
-        current_value = current.get(relation.name)
-        previous_value = previous.get(relation.name)
-
-        if cardinality == (1, 1):
-            if content_changed(
-                typing.cast(dict, current_value),
-                typing.cast(dict, previous_value),
-                schema=relation.entity,
-            ):
-                return True
-            continue
-
-        if cardinality == (0, 1):
-            if current_value is None and previous_value is None:
-                continue
-            if current_value is None or previous_value is None:
-                # The embedded entity was added or removed.
-                return True
-            if content_changed(
-                typing.cast(dict, current_value),
-                typing.cast(dict, previous_value),
-                schema=relation.entity,
-            ):
-                return True
-            continue
-
-        # Relation towards a list of embedded entities.  Match the current and
-        # previous instances by identity so that a reordering is not considered
-        # a change.  For a discriminated union, the identity includes the
-        # discriminator.
-        def identity(value: dict) -> Sequence[tuple[str, object]]:
-            return relation.entity.resolve(value).instance_identity(value)
-
-        current_items = {
-            identity(item): item
-            for item in typing.cast(list[dict], current_value or [])
-        }
-        previous_items = {
-            identity(item): item
-            for item in typing.cast(list[dict], previous_value or [])
-        }
-        if current_items.keys() != previous_items.keys():
-            # An embedded entity was added or removed.
-            return True
-        for key, current_item in current_items.items():
-            if content_changed(
-                current_item, previous_items[key], schema=relation.entity
-            ):
-                return True
-
-    return False
-
-
-def child_operation(
-    parent_operation: typing.Literal["create", "update", "delete"],
-    current: dict,
-    baseline: dict | None,
-    *,
-    schema: slice.SliceEntitySchema,
-) -> typing.Literal["create", "update", "delete"]:
-    """
-    Decide the operation to attach to an embedded slice element that is present
-    in the current version of a slice.
-
-    - When the parent is being deleted, the element is deleted too.
-    - When the element has no counterpart in the version immediately preceding
-      the current one, it is being created.
-    - Otherwise, the element is only marked as updated if its content actually
-      changed compared to that preceding version, and left as a creation when
-      it didn't (it is part of the desired state but carries no change).
-
-    Elements absent from the current version (removed) are handled separately
-    by the caller and always marked as deleted.
-
-    :param parent_operation: The operation attached to the parent element.
-    :param current: The attributes of the element in the current version.
-    :param baseline: The attributes of the element in the version immediately
-        preceding the current one, or None when the element is new.
-    :param schema: The schema of the element.
-    """
-    if parent_operation == const.SLICE_DELETE:
-        return const.SLICE_DELETE
-    if baseline is None:
-        return const.SLICE_CREATE
-    return (
-        const.SLICE_UPDATE
-        if content_changed(current, baseline, schema=schema)
-        else const.SLICE_CREATE
-    )
-
-
 def merge_attributes(
     current: dict,
     previous: dict | None,
@@ -1351,7 +1179,6 @@ def merge_attributes(
     operation: typing.Literal["create", "update", "delete"],
     path: dict_path.DictPath,
     schema: slice.SliceEntitySchema,
-    baseline: dict | None = None,
 ) -> dict:
     """
     Construct a merge of the current and previous attributes, inserting
@@ -1360,17 +1187,6 @@ def merge_attributes(
     is provided.  We can only merge dicts, identifying any nested dict
     by the key that leads to it.  Any other type will be considered to be
     a primitive and the value of the current will be kept unmodified.
-
-    :param current: The attributes of the element in the current version.
-    :param previous: The previously emitted attributes of the element, used to
-        carry over the embedded entities that were removed (and must keep being
-        purged).  It may collapse more than one older version together.
-    :param operation: The operation to attach to this element.
-    :param path: The path leading to this element from the slice root.
-    :param schema: The schema of the element being merged.
-    :param baseline: The attributes of the element in the version immediately
-        preceding the current one, used to decide whether each embedded element
-        changed.  None when the element is new or being deleted.
     """
     merged = {
         "operation": operation,
@@ -1395,26 +1211,16 @@ def merge_attributes(
         if cardinality == (1, 1):
             # The relation is mandatory, we will always have the
             # current attributes
-            current_value = typing.cast(dict, current[relation.name])
-            previous_value = (
-                typing.cast(dict, previous[relation.name])
-                if previous is not None
-                else None
-            )
-            baseline_value = (
-                typing.cast(dict, baseline[relation.name])
-                if baseline is not None
-                else None
-            )
             merged[relation.name] = merge_attributes(
-                current=current_value,
-                previous=previous_value,
-                operation=child_operation(
-                    operation, current_value, baseline_value, schema=relation.entity
+                current=typing.cast(dict, current[relation.name]),
+                previous=(
+                    typing.cast(dict, previous[relation.name])
+                    if previous is not None
+                    else None
                 ),
+                operation=operation,
                 path=path + dict_path.InDict(relation.name),
                 schema=relation.entity,
-                baseline=baseline_value,
             )
             continue
 
@@ -1425,11 +1231,6 @@ def merge_attributes(
             previous_value = (
                 typing.cast(dict | None, previous.get(relation.name))
                 if previous is not None
-                else None
-            )
-            baseline_value = (
-                typing.cast(dict | None, baseline.get(relation.name))
-                if baseline is not None
                 else None
             )
             item_path = path + dict_path.InDict(relation.name)
@@ -1449,15 +1250,17 @@ def merge_attributes(
                     merged[relation.name] = merge_attributes(
                         current_value,
                         previous_value,
-                        operation=child_operation(
-                            operation,
-                            current_value,
-                            baseline_value,
-                            schema=relation.entity,
+                        operation=(
+                            operation
+                            if operation == const.SLICE_DELETE
+                            else (
+                                const.SLICE_CREATE
+                                if previous_value is None
+                                else const.SLICE_UPDATE
+                            )
                         ),
                         path=item_path,
                         schema=relation.entity,
-                        baseline=baseline_value,
                     )
                 case _:
                     raise ValueError()
@@ -1477,12 +1280,6 @@ def merge_attributes(
             identity(previous_value): previous_value
             for previous_value in typing.cast(
                 list[dict], previous[relation.name] if previous is not None else []
-            )
-        }
-        baseline_values = {
-            identity(baseline_value): baseline_value
-            for baseline_value in typing.cast(
-                list[dict], baseline[relation.name] if baseline is not None else []
             )
         }
 
@@ -1508,7 +1305,6 @@ def merge_attributes(
         for key in all_identities:
             current_value = current_values.get(key)
             previous_value = previous_values.get(key)
-            baseline_value = baseline_values.get(key)
             item_path = path + dict_path.KeyedList(relation.name, key)
             match (current_value, previous_value):
                 case None, dict():
@@ -1527,15 +1323,17 @@ def merge_attributes(
                         merge_attributes(
                             current_value,
                             previous_value,
-                            operation=child_operation(
-                                operation,
-                                current_value,
-                                baseline_value,
-                                schema=relation.entity,
+                            operation=(
+                                operation
+                                if operation == const.SLICE_DELETE
+                                else (
+                                    const.SLICE_CREATE
+                                    if previous_value is None
+                                    else const.SLICE_UPDATE
+                                )
                             ),
                             path=item_path,
                             schema=relation.entity,
-                            baseline=baseline_value,
                         )
                     )
                 case _:

--- a/inmanta_plugins/git_ops/store.py
+++ b/inmanta_plugins/git_ops/store.py
@@ -572,6 +572,44 @@ class SliceStore[S: slice.SliceObjectABC]:
 
         return self.current_slices
 
+    def _preceding_versions(self, name: str, current: Slice) -> list[dict]:
+        """
+        Return the attributes of all the active versions of the slice that
+        precede the current one, sorted from the most to the least recent.
+
+        :param name: The name of the slice.
+        :param current: The slice currently in use for this name.
+        """
+        previous = [
+            s.attributes
+            for s in sorted(
+                self.load_active_slices().get(name, []),
+                key=lambda s: s.version,
+                reverse=True,
+            )
+        ]
+        if current == self.get_latest_slice(name):
+            # The current slice is the latest active one, drop it so we only
+            # keep the versions strictly preceding it.
+            previous = previous[1:]
+        return previous
+
+    def previous_version_attributes(self, name: str) -> dict | None:
+        """
+        Get the attributes of the version immediately preceding the current
+        one, or None if the slice has no previous version.
+
+        Unlike load_previous_slices, the returned attributes are not collapsed
+        together with even older versions: they are the raw content of the
+        immediately preceding version.  This is the reference to use when
+        deciding whether a slice element changed, as deletions carried over
+        from older versions are not part of the immediately preceding content.
+
+        :param name: The name of the slice.
+        """
+        previous = self._preceding_versions(name, self.load_current_slices()[name])
+        return previous[0] if previous else None
+
     def load_previous_slices(self) -> dict[str, Slice]:
         """
         Load all the previous slices (for slices which have an older version
@@ -580,22 +618,9 @@ class SliceStore[S: slice.SliceObjectABC]:
         if self.previous_slices is not None:
             return self.previous_slices
 
-        active_slices = self.load_active_slices()
-
         self.previous_slices: dict[str, Slice] = {}
         for s, current in self.load_current_slices().items():
-            latest = self.get_latest_slice(s)
-
-            previous = [
-                s.attributes
-                for s in sorted(
-                    active_slices.get(s, []),
-                    key=lambda s: s.version,
-                    reverse=True,
-                )
-            ]
-            if current == latest:
-                previous = previous[1:]
+            previous = self._preceding_versions(s, current)
 
             while len(previous) >= 2:
                 p_current = previous[0]
@@ -665,14 +690,36 @@ class SliceStore[S: slice.SliceObjectABC]:
                     schema=self.schema.entity_schema(),
                 )
             else:
-                # Normal merge
+                # Normal merge.  The slice is a creation when it has no
+                # previous version, an update when its content changed compared
+                # to the version immediately preceding it, and is otherwise
+                # left as a creation: it is part of the desired state but
+                # carries no change.
                 new = s not in previous_slices
+                if new:
+                    operation: typing.Literal["create", "update", "delete"] = (
+                        const.SLICE_CREATE
+                    )
+                    baseline = None
+                else:
+                    baseline = self.previous_version_attributes(s)
+                    assert baseline is not None
+                    operation = (
+                        const.SLICE_UPDATE
+                        if content_changed(
+                            current.attributes,
+                            baseline,
+                            schema=self.schema.entity_schema(),
+                        )
+                        else const.SLICE_CREATE
+                    )
                 attributes = merge_attributes(
                     current=current.attributes,
                     previous=None if new else previous_slices[s].attributes,
-                    operation="create" if new else "update",
+                    operation=operation,
                     path=dict_path.NullPath(),
                     schema=self.schema.entity_schema(),
+                    baseline=baseline,
                 )
 
             # Merge the current and previous slices together
@@ -1172,6 +1219,131 @@ def clear_project_paths() -> None:
         store._active_path = None
 
 
+def content_changed(
+    current: dict,
+    previous: dict,
+    *,
+    schema: slice.SliceEntitySchema,
+) -> bool:
+    """
+    Determine whether the content of a slice element changed between the
+    version immediately preceding the current one and the current version.
+
+    The comparison is recursive: an element changed if any of its own
+    (primitive) attributes differ, or if any of its embedded elements was
+    added, removed or itself changed.  The inserted "operation" and "path"
+    metadata are ignored, as they are not part of the user-defined content.
+
+    :param current: The attributes of the element in the current version.
+    :param previous: The attributes of the element in the version immediately
+        preceding the current one.
+    :param schema: The schema of the element being compared.
+    """
+    # When the schema is the base of a discriminated union, resolve the
+    # concrete sub entity matching the current instance.
+    schema = schema.resolve(current)
+
+    # Compare the primitive attributes, ignoring the inserted metadata.
+    for attribute in schema.all_attributes():
+        if attribute.name in ["operation", "path"]:
+            continue
+        if current.get(attribute.name) != previous.get(attribute.name):
+            return True
+
+    # Compare the embedded entities.
+    for relation in schema.all_relations():
+        cardinality = (relation.cardinality_min, relation.cardinality_max)
+        current_value = current.get(relation.name)
+        previous_value = previous.get(relation.name)
+
+        if cardinality == (1, 1):
+            if content_changed(
+                typing.cast(dict, current_value),
+                typing.cast(dict, previous_value),
+                schema=relation.entity,
+            ):
+                return True
+            continue
+
+        if cardinality == (0, 1):
+            if current_value is None and previous_value is None:
+                continue
+            if current_value is None or previous_value is None:
+                # The embedded entity was added or removed.
+                return True
+            if content_changed(
+                typing.cast(dict, current_value),
+                typing.cast(dict, previous_value),
+                schema=relation.entity,
+            ):
+                return True
+            continue
+
+        # Relation towards a list of embedded entities.  Match the current and
+        # previous instances by identity so that a reordering is not considered
+        # a change.  For a discriminated union, the identity includes the
+        # discriminator.
+        def identity(value: dict) -> Sequence[tuple[str, object]]:
+            return relation.entity.resolve(value).instance_identity(value)
+
+        current_items = {
+            identity(item): item
+            for item in typing.cast(list[dict], current_value or [])
+        }
+        previous_items = {
+            identity(item): item
+            for item in typing.cast(list[dict], previous_value or [])
+        }
+        if current_items.keys() != previous_items.keys():
+            # An embedded entity was added or removed.
+            return True
+        for key, current_item in current_items.items():
+            if content_changed(
+                current_item, previous_items[key], schema=relation.entity
+            ):
+                return True
+
+    return False
+
+
+def child_operation(
+    parent_operation: typing.Literal["create", "update", "delete"],
+    current: dict,
+    baseline: dict | None,
+    *,
+    schema: slice.SliceEntitySchema,
+) -> typing.Literal["create", "update", "delete"]:
+    """
+    Decide the operation to attach to an embedded slice element that is present
+    in the current version of a slice.
+
+    - When the parent is being deleted, the element is deleted too.
+    - When the element has no counterpart in the version immediately preceding
+      the current one, it is being created.
+    - Otherwise, the element is only marked as updated if its content actually
+      changed compared to that preceding version, and left as a creation when
+      it didn't (it is part of the desired state but carries no change).
+
+    Elements absent from the current version (removed) are handled separately
+    by the caller and always marked as deleted.
+
+    :param parent_operation: The operation attached to the parent element.
+    :param current: The attributes of the element in the current version.
+    :param baseline: The attributes of the element in the version immediately
+        preceding the current one, or None when the element is new.
+    :param schema: The schema of the element.
+    """
+    if parent_operation == const.SLICE_DELETE:
+        return const.SLICE_DELETE
+    if baseline is None:
+        return const.SLICE_CREATE
+    return (
+        const.SLICE_UPDATE
+        if content_changed(current, baseline, schema=schema)
+        else const.SLICE_CREATE
+    )
+
+
 def merge_attributes(
     current: dict,
     previous: dict | None,
@@ -1179,6 +1351,7 @@ def merge_attributes(
     operation: typing.Literal["create", "update", "delete"],
     path: dict_path.DictPath,
     schema: slice.SliceEntitySchema,
+    baseline: dict | None = None,
 ) -> dict:
     """
     Construct a merge of the current and previous attributes, inserting
@@ -1187,6 +1360,17 @@ def merge_attributes(
     is provided.  We can only merge dicts, identifying any nested dict
     by the key that leads to it.  Any other type will be considered to be
     a primitive and the value of the current will be kept unmodified.
+
+    :param current: The attributes of the element in the current version.
+    :param previous: The previously emitted attributes of the element, used to
+        carry over the embedded entities that were removed (and must keep being
+        purged).  It may collapse more than one older version together.
+    :param operation: The operation to attach to this element.
+    :param path: The path leading to this element from the slice root.
+    :param schema: The schema of the element being merged.
+    :param baseline: The attributes of the element in the version immediately
+        preceding the current one, used to decide whether each embedded element
+        changed.  None when the element is new or being deleted.
     """
     merged = {
         "operation": operation,
@@ -1211,16 +1395,26 @@ def merge_attributes(
         if cardinality == (1, 1):
             # The relation is mandatory, we will always have the
             # current attributes
+            current_value = typing.cast(dict, current[relation.name])
+            previous_value = (
+                typing.cast(dict, previous[relation.name])
+                if previous is not None
+                else None
+            )
+            baseline_value = (
+                typing.cast(dict, baseline[relation.name])
+                if baseline is not None
+                else None
+            )
             merged[relation.name] = merge_attributes(
-                current=typing.cast(dict, current[relation.name]),
-                previous=(
-                    typing.cast(dict, previous[relation.name])
-                    if previous is not None
-                    else None
+                current=current_value,
+                previous=previous_value,
+                operation=child_operation(
+                    operation, current_value, baseline_value, schema=relation.entity
                 ),
-                operation=operation,
                 path=path + dict_path.InDict(relation.name),
                 schema=relation.entity,
+                baseline=baseline_value,
             )
             continue
 
@@ -1231,6 +1425,11 @@ def merge_attributes(
             previous_value = (
                 typing.cast(dict | None, previous.get(relation.name))
                 if previous is not None
+                else None
+            )
+            baseline_value = (
+                typing.cast(dict | None, baseline.get(relation.name))
+                if baseline is not None
                 else None
             )
             item_path = path + dict_path.InDict(relation.name)
@@ -1250,17 +1449,15 @@ def merge_attributes(
                     merged[relation.name] = merge_attributes(
                         current_value,
                         previous_value,
-                        operation=(
-                            operation
-                            if operation == const.SLICE_DELETE
-                            else (
-                                const.SLICE_CREATE
-                                if previous_value is None
-                                else const.SLICE_UPDATE
-                            )
+                        operation=child_operation(
+                            operation,
+                            current_value,
+                            baseline_value,
+                            schema=relation.entity,
                         ),
                         path=item_path,
                         schema=relation.entity,
+                        baseline=baseline_value,
                     )
                 case _:
                     raise ValueError()
@@ -1280,6 +1477,12 @@ def merge_attributes(
             identity(previous_value): previous_value
             for previous_value in typing.cast(
                 list[dict], previous[relation.name] if previous is not None else []
+            )
+        }
+        baseline_values = {
+            identity(baseline_value): baseline_value
+            for baseline_value in typing.cast(
+                list[dict], baseline[relation.name] if baseline is not None else []
             )
         }
 
@@ -1305,6 +1508,7 @@ def merge_attributes(
         for key in all_identities:
             current_value = current_values.get(key)
             previous_value = previous_values.get(key)
+            baseline_value = baseline_values.get(key)
             item_path = path + dict_path.KeyedList(relation.name, key)
             match (current_value, previous_value):
                 case None, dict():
@@ -1323,17 +1527,15 @@ def merge_attributes(
                         merge_attributes(
                             current_value,
                             previous_value,
-                            operation=(
-                                operation
-                                if operation == const.SLICE_DELETE
-                                else (
-                                    const.SLICE_CREATE
-                                    if previous_value is None
-                                    else const.SLICE_UPDATE
-                                )
+                            operation=child_operation(
+                                operation,
+                                current_value,
+                                baseline_value,
+                                schema=relation.entity,
                             ),
                             path=item_path,
                             schema=relation.entity,
+                            baseline=baseline_value,
                         )
                     )
                 case _:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inmanta-module-git-ops
-version = 0.5.2
+version = 0.6.0
 description = Declarative parametrization, extension and validation of Inmanta DSL models.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_unroll.py
+++ b/tests/test_unroll.py
@@ -728,8 +728,9 @@ def test_update_operation_only_on_changed_content(
         "embedded_sequence[name=y]": "create",
     }
 
-    # Third version: remove y, leave everything else untouched.  Only the slice
-    # itself changed (it lost an element); x stays a creation.
+    # Third version: remove y, leave everything else untouched.
+    # The slice is updated;
+    # x remains changed as it has multiple different versions
     a_v3 = copy.deepcopy(a_v2)
     a_v3["embedded_sequence"] = a_v3["embedded_sequence"][:1]
     (store.active_path / "a@v3.json").write_text(json.dumps(a_v3))
@@ -737,7 +738,7 @@ def test_update_operation_only_on_changed_content(
         ".": "update",
         "embedded_required": "create",
         "embedded_optional": "create",
-        "embedded_sequence[name=x]": "create",
+        "embedded_sequence[name=x]": "update",
         "embedded_sequence[name=y]": "delete",
     }
 
@@ -832,13 +833,13 @@ def test_update_operation_ignores_deletions_carried_from_older_versions(
 
     # v3: only the root changes.  The deletion of "drop" is carried forward
     # (still emitted as a delete), but embedded_required did not change since
-    # v2 and must stay a creation, not an update.
+    # v2 and must stay an update.
     a_v3 = copy.deepcopy(a_v2)
     a_v3["description"] = "v3"
     (store.active_path / "a@v3.json").write_text(json.dumps(a_v3))
     assert _operations_by_path(project, store.name) == {
         ".": "update",
-        "embedded_required": "create",
+        "embedded_required": "update",
         "embedded_required.recursive_slice[name=keep]": "create",
         "embedded_required.recursive_slice[name=drop]": "delete",
     }

--- a/tests/test_unroll.py
+++ b/tests/test_unroll.py
@@ -316,7 +316,7 @@ def test_unroll_slices(
         "path": ".",
         "version": 2,
         "embedded_required": {
-            "operation": "update",
+            "operation": "create",
             "path": "embedded_required",
             "name": "aa",
             "description": None,
@@ -413,7 +413,7 @@ def test_unroll_slices(
         "path": ".",
         "version": 3,
         "embedded_required": {
-            "operation": "update",
+            "operation": "create",
             "path": "embedded_required",
             "name": "aa",
             "description": None,
@@ -421,7 +421,7 @@ def test_unroll_slices(
             "recursive_slice": [],
         },
         "embedded_optional": {
-            "operation": "update",
+            "operation": "create",
             "path": "embedded_optional",
             "name": "ab",
             "description": None,
@@ -622,6 +622,228 @@ def test_desired_state_stability(project: Project, tmp_path: pathlib.Path) -> No
     assert desired_state_value() == [a_merged_val, b_val]
 
 
+def _embedded(
+    name: str,
+    description: str | None = None,
+    recursive_slice: list[dict] | None = None,
+) -> dict:
+    """
+    Build the source attributes of an example::slices::recursive::EmbeddedSlice.
+    """
+    return {
+        "name": name,
+        "description": description,
+        "unique_id": None,
+        "recursive_slice": recursive_slice if recursive_slice is not None else [],
+    }
+
+
+def _operations_by_path(project: Project, store_name: str) -> dict[str, str]:
+    """
+    Compile a model that unrolls the slices of the given store and return a
+    mapping from the path of every slice element to the operation attached to
+    it.  The store is expected to contain a single slice.
+    """
+    model = f"""
+        import git_ops
+        import unittest
+
+        unittest::Resource(
+            name="{store_name}",
+            desired_value=std::json_dumps(
+                [
+                    slice["attributes"]
+                    for slice in git_ops::unroll_slices("{store_name}")
+                ]
+            )
+        )
+    """
+    project.compile(model, no_dedent=False)
+    resource = project.get_resource("unittest::Resource")
+    assert resource is not None
+
+    operations: dict[str, str] = {}
+
+    def collect(element: object) -> None:
+        if isinstance(element, dict):
+            if "operation" in element and "path" in element:
+                operations[element["path"]] = element["operation"]
+            for value in element.values():
+                collect(value)
+        elif isinstance(element, list):
+            for value in element:
+                collect(value)
+
+    collect(json.loads(resource.desired_value))
+    return operations
+
+
+def test_update_operation_only_on_changed_content(
+    project: Project, tmp_path: pathlib.Path
+) -> None:
+    """
+    When a slice gains a new version, the "update" operation must only be
+    attached to the slice elements whose content actually changed.  Unchanged
+    elements keep the "create" operation, new elements are created and removed
+    elements are deleted.
+    """
+    store = SliceStore(
+        name="test_scope",
+        folder="file://" + str(tmp_path / "test"),
+        schema=Slice,
+    )
+
+    # The empty store unrolls to nothing (and the active folder gets created).
+    assert _operations_by_path(project, store.name) == {}
+
+    # First version: everything is created.
+    a_v1 = {
+        "name": "a",
+        "description": None,
+        "unique_id": None,
+        "embedded_required": _embedded("req"),
+        "embedded_optional": None,
+        "embedded_sequence": [_embedded("x", "1"), _embedded("y", "1")],
+    }
+    (store.active_path / "a@v1.json").write_text(json.dumps(a_v1))
+    assert _operations_by_path(project, store.name) == {
+        ".": "create",
+        "embedded_required": "create",
+        "embedded_sequence[name=x]": "create",
+        "embedded_sequence[name=y]": "create",
+    }
+
+    # Second version: change x, leave y and embedded_required untouched, and
+    # add an optional embedded slice.  Only the slice itself, x and the new
+    # optional slice carry a change.
+    a_v2 = copy.deepcopy(a_v1)
+    a_v2["embedded_sequence"][0]["description"] = "2"
+    a_v2["embedded_optional"] = _embedded("opt")
+    (store.active_path / "a@v2.json").write_text(json.dumps(a_v2))
+    assert _operations_by_path(project, store.name) == {
+        ".": "update",
+        "embedded_required": "create",
+        "embedded_optional": "create",
+        "embedded_sequence[name=x]": "update",
+        "embedded_sequence[name=y]": "create",
+    }
+
+    # Third version: remove y, leave everything else untouched.  Only the slice
+    # itself changed (it lost an element); x stays a creation.
+    a_v3 = copy.deepcopy(a_v2)
+    a_v3["embedded_sequence"] = a_v3["embedded_sequence"][:1]
+    (store.active_path / "a@v3.json").write_text(json.dumps(a_v3))
+    assert _operations_by_path(project, store.name) == {
+        ".": "update",
+        "embedded_required": "create",
+        "embedded_optional": "create",
+        "embedded_sequence[name=x]": "create",
+        "embedded_sequence[name=y]": "delete",
+    }
+
+
+def test_update_operation_propagates_through_embedded_tree(
+    project: Project, tmp_path: pathlib.Path
+) -> None:
+    """
+    A change deep inside an embedded slice marks the whole chain of parent
+    elements as updated, while unaffected sibling elements stay created.
+    """
+    store = SliceStore(
+        name="test_deep",
+        folder="file://" + str(tmp_path / "test"),
+        schema=Slice,
+    )
+
+    # The empty store unrolls to nothing (and the active folder gets created).
+    assert _operations_by_path(project, store.name) == {}
+
+    a_v1 = {
+        "name": "a",
+        "description": None,
+        "unique_id": None,
+        "embedded_required": _embedded("req", recursive_slice=[_embedded("leaf", "1")]),
+        "embedded_optional": None,
+        "embedded_sequence": [_embedded("sibling")],
+    }
+    (store.active_path / "a@v1.json").write_text(json.dumps(a_v1))
+    assert _operations_by_path(project, store.name) == {
+        ".": "create",
+        "embedded_required": "create",
+        "embedded_required.recursive_slice[name=leaf]": "create",
+        "embedded_sequence[name=sibling]": "create",
+    }
+
+    # Change a leaf deep inside embedded_required.  The change bubbles up to
+    # embedded_required and the slice itself, but the sibling stays a creation.
+    a_v2 = copy.deepcopy(a_v1)
+    a_v2["embedded_required"]["recursive_slice"][0]["description"] = "2"
+    (store.active_path / "a@v2.json").write_text(json.dumps(a_v2))
+    assert _operations_by_path(project, store.name) == {
+        ".": "update",
+        "embedded_required": "update",
+        "embedded_required.recursive_slice[name=leaf]": "update",
+        "embedded_sequence[name=sibling]": "create",
+    }
+
+
+def test_update_operation_ignores_deletions_carried_from_older_versions(
+    project: Project, tmp_path: pathlib.Path
+) -> None:
+    """
+    Deletions from versions older than the one immediately preceding the
+    current one keep being emitted (so the deleted elements stay purged), but
+    they must not, on their own, make their unchanged parent look updated: an
+    element is only updated when its content changed since the previous
+    version.
+    """
+    store = SliceStore(
+        name="test_carried",
+        folder="file://" + str(tmp_path / "test"),
+        schema=Slice,
+    )
+
+    # The empty store unrolls to nothing (and the active folder gets created).
+    assert _operations_by_path(project, store.name) == {}
+
+    # v1: embedded_required holds two nested slices, "keep" and "drop".
+    a_v1 = {
+        "name": "a",
+        "description": "v1",
+        "unique_id": None,
+        "embedded_required": _embedded(
+            "req", recursive_slice=[_embedded("keep"), _embedded("drop")]
+        ),
+        "embedded_optional": None,
+        "embedded_sequence": [],
+    }
+    (store.active_path / "a@v1.json").write_text(json.dumps(a_v1))
+
+    # v2: "drop" is removed, so embedded_required changed and is updated.
+    a_v2 = copy.deepcopy(a_v1)
+    a_v2["embedded_required"]["recursive_slice"] = [_embedded("keep")]
+    (store.active_path / "a@v2.json").write_text(json.dumps(a_v2))
+    assert _operations_by_path(project, store.name) == {
+        ".": "update",
+        "embedded_required": "update",
+        "embedded_required.recursive_slice[name=keep]": "create",
+        "embedded_required.recursive_slice[name=drop]": "delete",
+    }
+
+    # v3: only the root changes.  The deletion of "drop" is carried forward
+    # (still emitted as a delete), but embedded_required did not change since
+    # v2 and must stay a creation, not an update.
+    a_v3 = copy.deepcopy(a_v2)
+    a_v3["description"] = "v3"
+    (store.active_path / "a@v3.json").write_text(json.dumps(a_v3))
+    assert _operations_by_path(project, store.name) == {
+        ".": "update",
+        "embedded_required": "create",
+        "embedded_required.recursive_slice[name=keep]": "create",
+        "embedded_required.recursive_slice[name=drop]": "delete",
+    }
+
+
 def test_delete_embedded_entities(project: Project, tmp_path: pathlib.Path) -> None:
     """
     Test the unrolling behavior when an embedded slice is being removed.
@@ -791,14 +1013,14 @@ def test_delete_embedded_entities(project: Project, tmp_path: pathlib.Path) -> N
             "description": None,
             "unique_id": None,
             "embedded_required": {
-                "operation": "update",
+                "operation": "create",
                 "path": "embedded_required",
                 "name": "a",
                 "description": None,
                 "unique_id": None,
                 "recursive_slice": [
                     {
-                        "operation": "update",
+                        "operation": "create",
                         "path": "embedded_required.recursive_slice[name=a]",
                         "name": "a",
                         "description": None,


### PR DESCRIPTION
- Only insert the `update` operation on slice elements whose content actually changed, instead of on every element of a slice that has more than one version. Unchanged elements keep the `create` operation; `create` and `delete` are unaffected.