### PR TITLE
Issue/ctx in processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.7.0 - ?
 
+- Add git_ops::processors::get_template_value processor to convert template references to the rendered template.
 - Add automatic inmanta.plugins.Context injection to the attribute_processor decorator, passed as the first positional argument like the native plugin decorator does.
 
 ## v0.6.0 - 2026-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v0.6.1 - ?
+## v0.7.0 - ?
 
+- Add automatic inmanta.plugins.Context injection to the attribute_processor decorator, passed as the first positional argument like the native plugin decorator does.
 
 ## v0.6.0 - 2026-06-17
 

--- a/inmanta_plugins/git_ops/__init__.py
+++ b/inmanta_plugins/git_ops/__init__.py
@@ -18,11 +18,12 @@ Contact: edvgui@gmail.com
 
 import functools
 import importlib
+import inspect
 import typing
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 
-from inmanta.plugins import Plugin, plugin
+from inmanta.plugins import Context, Plugin, plugin
 from inmanta.util import dict_path
 from inmanta_git_ops import const
 
@@ -211,7 +212,31 @@ class AttributeProcessorFunction[**P, R](typing.Protocol):
         pass
 
 
-def attribute_processor[F: AttributeProcessorFunction](func: F) -> F:
+class ContextAttributeProcessorFunction[**P, R](typing.Protocol):
+    """
+    Define the interface that processor functions requesting the compiler
+    context must implement.  The context is passed automatically by the compiler
+    as the first positional argument.
+    """
+
+    def __call__(
+        self,
+        context: Context,
+        store_name: str,
+        name: str,
+        path: str,
+        previous_value: R | None,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R:
+        pass
+
+
+def attribute_processor[
+    F: AttributeProcessorFunction | ContextAttributeProcessorFunction
+](
+    func: F,
+) -> F:
     """
     Register a function as an attribute processor.  Attribute processors are
     called during update compile to process the value of a slice attribute and
@@ -233,8 +258,44 @@ def attribute_processor[F: AttributeProcessorFunction](func: F) -> F:
             else:
                 return None
 
+    Similarly to the native plugin decorator, a processor can request the
+    compiler context by annotating an argument with ``inmanta.plugins.Context``.
+    When present, it is automatically passed by the compiler and must be the
+    first positional argument:
+
+    .. code-block:: python
+
+        @attribute_processor
+        def upper(
+            context: Context,
+            store_name: str,
+            name: str,
+            path: str,
+            previous_value: str | None,
+        ) -> str | None:
+            ...
+
     :param func: The processor function to register and wrap.
     """
+    # Detect whether the processor requests the compiler context.  Mirroring the
+    # native plugin decorator, the context is injected by the compiler and, for
+    # processors, is only supported as the first positional argument.
+    arg_spec = inspect.getfullargspec(func)
+    expects_context = (
+        bool(arg_spec.args) and arg_spec.annotations.get(arg_spec.args[0]) is Context
+    )
+    misplaced_context = [
+        arg
+        for arg in (*arg_spec.args[1:], *arg_spec.kwonlyargs)
+        if arg_spec.annotations.get(arg) is Context
+    ]
+    if misplaced_context:
+        func_name = getattr(func, "__name__", repr(func))
+        raise ValueError(
+            f"Processor {func_name!r} declares a Context argument "
+            f"({misplaced_context[0]!r}) that is not the first positional "
+            f"argument.  The Context must be the first positional argument."
+        )
 
     # Make sure that the inmanta compiler sees this wrapped function the same way
     # as the plugin it wraps, with its annotations and defaults
@@ -244,10 +305,6 @@ def attribute_processor[F: AttributeProcessorFunction](func: F) -> F:
     )
     def wrapped(
         self: Plugin,
-        store_name: str,
-        name: str,
-        path: str,
-        previous_value: object,
         *args: object,
         **kwargs: object,
     ) -> object:
@@ -255,13 +312,27 @@ def attribute_processor[F: AttributeProcessorFunction](func: F) -> F:
         Wrapper function, getting the value from the slice and, if this is an
         update compile, also call the processor function and return its result.
 
-        :param store_name: The name of the slice store in which the slice is.
-        :param name: The name of the slice.
-        :param path: The path within the slice's attributes towards the value that
-            should be updated.
-        :param previous_value: The value that is currently in the slice for the
-            given attribute.
+        The positional arguments are, in order: an optional Context object
+        (injected by the compiler when the processor requests it), the slice
+        store name, the slice name, the path within the slice's attributes
+        towards the value that should be updated, and the value that is
+        currently in the slice for that attribute (recomputed here and ignored
+        if provided).
         """
+        # The compiler injects the optional Context as the first positional
+        # argument, shifting the slice-related arguments by one position.
+        offset = 1 if expects_context else 0
+        store_name = typing.cast(str, args[offset])
+        name = typing.cast(str, args[offset + 1])
+        path = typing.cast(str, args[offset + 2])
+
+        # The arguments forwarded as-is to the processor: the optional context
+        # followed by the slice store name, slice name and path.  The recomputed
+        # previous_value sits right after them (at index offset + 3) and is
+        # dropped here, any further positional argument is forwarded.
+        forward_prefix = args[: offset + 3]
+        extra_args = args[offset + 4 :]
+
         # Get the value that is currently set in the slice
         previous_value = get_slice_attribute(store_name, name, path)
 
@@ -277,17 +348,19 @@ def attribute_processor[F: AttributeProcessorFunction](func: F) -> F:
             # We can not modify a deleted slice, stick to the previous value
             return previous_value
 
-        # Call the processor and set the new value in the slice
+        # Call the processor and set the new value in the slice.  The processor
+        # is called dynamically: depending on `expects_context`, the forwarded
+        # arguments either start with the injected context or directly with the
+        # slice store name.
+        processor: typing.Callable[..., object] = func
         return update_slice_attribute(
             store_name,
             name,
             path,
-            func(
-                store_name,
-                name,
-                path,
+            processor(
+                *forward_prefix,
                 previous_value,
-                *args,
+                *extra_args,
                 **kwargs,
             ),
         )

--- a/inmanta_plugins/git_ops/processors.py
+++ b/inmanta_plugins/git_ops/processors.py
@@ -20,7 +20,9 @@ import itertools
 import typing
 from collections.abc import Collection, Iterator, Mapping
 
-from inmanta.plugins import ModelType, plugin
+import inmanta_plugins.config
+
+from inmanta.plugins import Context, ModelType, plugin
 from inmanta.util import dict_path
 from inmanta_plugins.git_ops import Slice, attribute_processor, store
 
@@ -178,3 +180,39 @@ def simple_value(
         return value
     else:
         return previous_value
+
+
+@attribute_processor
+def get_template_value(
+    context: Context,
+    store_name: str,
+    name: str,
+    path: str,
+    previous_value: object | None = None,
+    **kwargs: object,
+) -> object:
+    """
+    Attribute processor counterpart of the config::get_template_value plugin.
+    The value currently stored in the slice is treated as a potential template
+    path: if it resolves to a jinja (`.j2`) file, the template is rendered (with
+    access to the extra kwargs and to all the compiler plugins as filters) and
+    the result is saved back into the slice.  Otherwise the value is kept as is.
+
+    The compiler context is required to render the template and is passed
+    automatically as the first positional argument.
+
+    :param context: The compiler context, automatically injected.
+    :param store_name: The name of the slice store in which the slice is.
+    :param name: The name of the slice.
+    :param path: The path within the slice's attributes towards the value that
+        should be processed.
+    :param previous_value: The value currently stored in the slice for the given
+        attribute.
+    :param kwargs: Any value that should be accessible to the template.
+    """
+    return inmanta_plugins.config.get_template_value(
+        context,
+        {"value": previous_value},
+        "value",
+        **kwargs,
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inmanta-module-git-ops
-version = 0.6.1
+version = 0.7.0
 description = Declarative parametrization, extension and validation of Inmanta DSL models.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -16,12 +16,17 @@ limitations under the License.
 Contact: edvgui@gmail.com
 """
 
+import pathlib
+
 import pytest
 import yaml
 from inmanta_plugins.example.slices import recursive
+from inmanta_plugins.example.slices.recursive import EmbeddedSlice, Slice
 from pytest_inmanta.plugin import Project
 
-from inmanta_plugins.git_ops import const, processors
+from inmanta.plugins import Context
+from inmanta_plugins.git_ops import attribute_processor, const, processors
+from inmanta_plugins.git_ops.store import SliceStore
 
 
 def test_fs(project: Project, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -93,3 +98,69 @@ def test_fs(project: Project, monkeypatch: pytest.MonkeyPatch) -> None:
                 ),
             )()
         ) == {1, 2}
+
+
+def test_get_template_value(
+    project: Project, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Define a basic store
+    store = SliceStore(
+        name="test_template",
+        folder="file://" + str(tmp_path / "test"),
+        schema=Slice,
+    )
+
+    # A jinja template that the processor should render, using a value passed
+    # to it as keyword argument
+    template = tmp_path / "greeting.j2"
+    template.write_text("Hello {{ who }}")
+
+    model = """
+        import git_ops
+        import git_ops::processors
+
+        for slice in git_ops::unroll_slices("test_template"):
+            git_ops::processors::get_template_value(
+                slice["store_name"],
+                slice["name"],
+                "description",
+                who="world",
+            )
+        end
+    """
+
+    # Add one slice whose description points to the template
+    s1_obj = Slice(
+        name="a",
+        description="file://" + str(template),
+        embedded_required=EmbeddedSlice(
+            name="aa",
+        ),
+    )
+    s1 = store.source_path / "s1.yaml"
+    s1.parent.mkdir(parents=True, exist_ok=True)
+    s1.write_text(yaml.safe_dump(s1_obj.model_dump(mode="json")))
+
+    # The processor needs the compiler context to render the template, it should
+    # be passed automatically as first positional argument
+    with monkeypatch.context() as ctx:
+        ctx.setattr(const, "COMPILE_MODE", const.COMPILE_UPDATE)
+        project.compile(model, no_dedent=False)
+
+    # The template path should have been rendered and saved back in the slice
+    assert yaml.safe_load(s1.read_text())["description"] == "Hello world"
+
+
+def test_context_must_be_first_positional() -> None:
+    # A Context argument is only supported as the first positional argument
+    with pytest.raises(ValueError, match="first positional argument"):
+
+        @attribute_processor
+        def misplaced_context(
+            store_name: str,
+            name: str,
+            path: str,
+            context: Context,
+            previous_value: object | None = None,
+        ) -> object:
+            return previous_value


### PR DESCRIPTION
- Add git_ops::processors::get_template_value processor to convert template references to the rendered template.
- Add automatic inmanta.plugins.Context injection to the attribute_processor decorator, passed as the first positional argument like the native plugin decorator does.