### PR TITLE
Fix unstable ordering of generated index fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.7.1 - ?
 
+- Fix unstable ordering of index fields in the generated model: the generator now emits index fields in the order the keys are declared on the slice schema, instead of the arbitrary order of the entity's field set.
+
 
 ## v0.7.0 - 2026-06-20
 

--- a/inmanta_git_ops/generator.py
+++ b/inmanta_git_ops/generator.py
@@ -195,6 +195,39 @@ def get_attribute(
     )
 
 
+def get_key_fields(
+    entity: Entity,
+    keys: Sequence[str],
+    *,
+    parent_relation: EntityRelation | None,
+) -> Sequence[EntityField]:
+    """
+    Collect the fields that make up the index of an entity, in a stable order:
+    the parent relation first (when set), followed by the key attributes in the
+    exact order in which they are declared on the slice schema.
+
+    Iterating ``entity.all_fields()`` directly is not stable: it returns a set,
+    so the resulting index field order is arbitrary and changes from one
+    generation to the next.
+
+    :param entity: The entity whose key fields to collect.
+    :param keys: The names of the key attributes, in the desired order.
+    :param parent_relation: When set, the parent relation to prepend to the
+        index fields.
+    """
+    fields_by_name = {field.name: field for field in entity.all_fields()}
+
+    key_fields: dict[str, EntityField] = {}
+    if parent_relation is not None:
+        key_fields[parent_relation.name] = parent_relation
+
+    for key in keys:
+        if key in fields_by_name:
+            key_fields[key] = fields_by_name[key]
+
+    return list(key_fields.values())
+
+
 def get_relation(
     schema: slice.SliceEntityRelationSchema,
     *,
@@ -255,17 +288,15 @@ def get_relation(
                 )
                 builder.add_module_element(helper)
 
-                helper_key_fields: dict[str, EntityField] = {
-                    parent_relation.name: parent_relation,
-                }
-                for field in helper.all_fields():
-                    if field.name in sub_schema.keys:
-                        helper_key_fields[field.name] = field
                 builder.add_module_element(
                     Index(
                         path=helper.path,
                         entity=helper,
-                        fields=helper_key_fields.values(),
+                        fields=get_key_fields(
+                            helper,
+                            sub_schema.keys,
+                            parent_relation=parent_relation,
+                        ),
                     )
                 )
                 builder.add_module_element(
@@ -303,20 +334,15 @@ def get_relation(
 
         builder.add_module_element(embedded_entity)
 
-        key_fields: dict[str, EntityField] = {}
-
-        if parent_relation is not None:
-            key_fields[parent_relation.name] = parent_relation
-
-        for field in embedded_entity.all_fields():
-            if field.name in schema.entity.keys:
-                key_fields[field.name] = field
-
         builder.add_module_element(
             Index(
                 path=embedded_entity.path,
                 entity=embedded_entity,
-                fields=key_fields.values(),
+                fields=get_key_fields(
+                    embedded_entity,
+                    schema.entity.keys,
+                    parent_relation=parent_relation,
+                ),
             )
         )
 
@@ -431,20 +457,15 @@ def get_entity(
     # keys are carried by its concrete sub entities, which define their own
     # indexes, so no index is generated for the base itself.
     if (slice_root or parent_relation is not None) and schema.discriminator is None:
-        key_fields: dict[str, EntityField] = {}
-
-        if parent_relation is not None:
-            key_fields[parent_relation.name] = parent_relation
-
-        for field in entity.all_fields():
-            if field.name in schema.keys:
-                key_fields[field.name] = field
-
         builder.add_module_element(
             Index(
                 path=entity.path,
                 entity=entity,
-                fields=key_fields.values(),
+                fields=get_key_fields(
+                    entity,
+                    schema.keys,
+                    parent_relation=parent_relation,
+                ),
             )
         )
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,50 @@
+"""
+Copyright 2026 Guillaume Everarts de Velp
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: edvgui@gmail.com
+"""
+
+from inmanta_module_factory.inmanta import Index
+from inmanta_plugins.example.slices.fs import RootFolder
+
+from inmanta_git_ops import generator
+
+
+def test_index_field_order_matches_keys() -> None:
+    """
+    The generated index of an entity must list its fields in the exact order in
+    which the keys are declared on the slice schema.
+
+    The generator used to build the index by iterating ``entity.all_fields()``,
+    which returns a set: the resulting field order was arbitrary and unstable
+    from one generation to the next.  RootFolder declares its keys as
+    ``["root", "name"]`` where ``root`` is defined on the entity itself and
+    ``name`` is inherited, a case where the set iteration order is very unlikely
+    to match the declared order.
+    """
+    schema = RootFolder.entity_schema()
+    assert list(schema.keys) == ["root", "name"]
+
+    entity = generator.get_entity(schema, slice_root=True)
+
+    builder = generator.get_module_builder("example")
+    indexes = [
+        element
+        for element in builder._model_files[entity.path_string]
+        if isinstance(element, Index) and element.entity is entity
+    ]
+    assert len(indexes) == 1
+
+    assert [field.name for field in indexes[0].fields] == list(schema.keys)


### PR DESCRIPTION
_Claude opening this PR on behalf of Guillaume._

## Problem

The generator built each entity index by iterating `entity.all_fields()`, which returns a **set**. The resulting index field order was arbitrary and changed from one generation to the next — reproducible by running the tests with different `PYTHONHASHSEED` values.

## Fix

Order the index fields by the keys declared on the slice schema (parent relation first, then keys in declared order), via a new `get_key_fields` helper shared by the three index-generation sites in `generator.py`.

## Test

Added `tests/test_generator.py::test_index_field_order_matches_keys`, asserting `RootFolder`'s generated index lists its fields in the declared `["root", "name"]` order (`root` local, `name` inherited — a case where set iteration is very unlikely to match). Confirmed the test fails on the old code under some hash seeds and passes deterministically with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)